### PR TITLE
Correct theme_hook_suggestions order

### DIFF
--- a/cambridge_teasers.module
+++ b/cambridge_teasers.module
@@ -56,9 +56,9 @@ function cambridge_teasers_theme_registry_alter(&$theme_registry) {
  */
 function cambridge_teasers_preprocess_node(&$vars) {
   if (in_array($vars['view_mode'], array('teaser', 'vertical_teaser', 'sidebar_teaser', 'news_listing_item'))) {
+    $vars['theme_hook_suggestions'][] = 'node____' . $vars['view_mode'];
     $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__' . $vars['view_mode'];
     $vars['theme_hook_suggestions'][] = 'node__' . $vars['nid'] . '__' . $vars['view_mode'];
-    $vars['theme_hook_suggestions'][] = 'node____' . $vars['view_mode'];
     $vars['date'] = format_date($vars['node']->created, 'custom', 'j F Y');
   }
 }


### PR DESCRIPTION
Fixes #6.

(This also makes the `nid` form preferred to the content type form.)
