### PR TITLE
Remove shorthand ternary operator

### DIFF
--- a/templates/node----teaser.tpl.php
+++ b/templates/node----teaser.tpl.php
@@ -28,7 +28,7 @@ $has_image = isset($content['field_image']);
     <?php if ($has_image): ?>
       <div class="campl-column6">
         <div class="campl-content-container campl-horizontal-teaser-img">
-          <?php print render($content['field_image']) ? : '&nbsp;'; ?>
+          <?php print render($content['field_image']); ?>
         </div>
       </div>
     <?php endif; ?>


### PR DESCRIPTION
Shorthand ternary operators were introduced in PHP 5.3, so this breaks in 5.2 (see also https://github.com/misd-service-development/drupal-cambridge-theme/issues/28).

Since there's already a check to see if there is an image or not, the check is unnecessary anyhow.
