### PR TITLE
Wrap smart-trimmed text that has stripped HTML in a paragraph element

### DIFF
--- a/cambridge_teasers.module
+++ b/cambridge_teasers.module
@@ -72,3 +72,19 @@ function cambridge_teasers_preprocess_node(&$vars) {
     $vars['date'] = format_date($vars['node']->created, 'custom', 'j F Y');
   }
 }
+
+/**
+ * Implements template_preprocess_field().
+ */
+function cambridge_teasers_preprocess_field(&$vars) {
+  $view_modes = array('teaser', 'vertical_teaser', 'sidebar_teaser', 'news_listing_item');
+
+  if (in_array($vars['element']['#view_mode'], $view_modes) && 'smart_trim_format' === $vars['element']['#formatter']) {
+    foreach ($vars['items'] as $key => $value) {
+      if (FALSE === strpos($vars['items'][$key]['#markup'], '<')) {
+        // Wrap smart-trimmed text that has stripped HTML in a paragraph element.
+        $vars['items'][$key]['#markup'] = '<p>' . $vars['items'][$key]['#markup'] . '</p>';
+      }
+    }
+  }
+}


### PR DESCRIPTION
The [Smart Trim](https://drupal.org/project/smart_trim) module provides an improved way of automatically generating teaser text by allowing breaking at word boundaries and, more importantly, stripping HTML. The latter feature, however, removes everything, so the text is not even in a paragraph element:

![image](https://f.cloud.github.com/assets/1784740/2295363/0b61a66e-a08f-11e3-8147-80652d919fbb.png)

This PR tries to capture these cases and wraps the content in a paragraph element if no HTML is found (there might be an alternative/better way of doing this).
