### PR TITLE
Add borders around horizontal and vertical teasers

### DIFF
--- a/cambridge_teasers.info
+++ b/cambridge_teasers.info
@@ -7,3 +7,8 @@ project = cambridge_teasers
 dependencies[] = cambridge_image_styles
 dependencies[] = features
 features[features_api][] = api:2
+
+stylesheets[all][] = "css/teasers.css"
+
+scripts[] = 'js/teasers.js'
+scripts[] = 'js/jquery.matchHeight-min.js'

--- a/cambridge_teasers.module
+++ b/cambridge_teasers.module
@@ -37,26 +37,9 @@ function cambridge_teasers_entity_info_alter(&$entity_info) {
  * Implements hook_theme_registry_alter().
  */
 function cambridge_teasers_theme_registry_alter(&$theme_registry) {
-  $theme_registry['node____teaser'] = array(
-    'template' => drupal_get_path('module', 'cambridge_teasers') . '/templates/node----teaser',
-    'type' => 'module',
-  );
-  $theme_registry['node____vertical_teaser'] = array(
-    'template' => drupal_get_path('module', 'cambridge_teasers') . '/templates/node----vertical-teaser',
-    'type' => 'module',
-  );
-  $theme_registry['node____sidebar_teaser'] = array(
-    'template' => drupal_get_path('module', 'cambridge_teasers') . '/templates/node----sidebar-teaser',
-    'type' => 'module',
-  );
-  $theme_registry['node____focus_on_teaser'] = array(
-    'template' => drupal_get_path('module', 'cambridge_teasers') . '/templates/node----focus-on-teaser',
-    'type' => 'module',
-  );
-  $theme_registry['node____news_listing_item'] = array(
-    'template' => drupal_get_path('module', 'cambridge_teasers') . '/templates/node----news-listing-item',
-    'type' => 'module',
-  );
+  $module_path = drupal_get_path('module', 'cambridge_teasers') . '/templates';
+
+  _theme_process_registry($theme_registry, 'phptemplate', 'theme_engine', 'cambridge_teasers', $module_path);
 }
 
 /**

--- a/css/teasers.css
+++ b/css/teasers.css
@@ -1,0 +1,26 @@
+.campl-teasers-borders .campl-teaser-border {
+    border-left: 1px solid #e4e4e4;
+    margin-left: -1px;
+    border-right: 1px solid #e4e4e4;
+}
+
+.campl-teasers-borders.campl-column-first .campl-teaser-border {
+    border-left: 0;
+    margin-left: 0;
+}
+
+.campl-column-end.campl-teasers-borders .campl-teaser-border {
+    border-right: 0;
+}
+
+@media (min-width: 768px) {
+    .campl-hide-teaser-divider .campl-teaser-divider {
+        display: none;
+    }
+}
+
+@media (max-width: 767px) {
+    .campl-column-last.campl-hide-teaser-divider .campl-teaser-divider {
+        display: none;
+    }
+}

--- a/js/jquery.matchHeight-min.js
+++ b/js/jquery.matchHeight-min.js
@@ -1,0 +1,9 @@
+/**
+* jquery.matchHeight-min.js v0.5.1
+* http://brm.io/jquery-match-height/
+* License: MIT
+*/
+(function(b){b.fn.matchHeight=function(a){if(1>=this.length)return this;a="undefined"!==typeof a?a:!0;b.fn.matchHeight._groups.push({elements:this,byRow:a});b.fn.matchHeight._apply(this,a);return this};b.fn.matchHeight._apply=function(a,d){var c=b(a),e=[c];d&&(c.css({display:"block","padding-top":"0","padding-bottom":"0","border-top":"0","border-bottom":"0",height:"100px"}),e=k(c),c.css({display:"","padding-top":"","padding-bottom":"","border-top":"","border-bottom":"",height:""}));b.each(e,function(a,
+c){var d=b(c),e=0;d.each(function(){var a=b(this);a.css({display:"block",height:""});a.outerHeight(!1)>e&&(e=a.outerHeight(!1))});d.each(function(){var a=b(this),c=0;"border-box"!==a.css("box-sizing")&&(c+=f(a.css("border-top-width"))+f(a.css("border-bottom-width")),c+=f(a.css("padding-top"))+f(a.css("padding-bottom")));a.css("height",e-c)})});return this};b.fn.matchHeight._applyDataApi=function(){var a={};b("[data-match-height], [data-mh]").each(function(){var d=b(this),c=d.attr("data-match-height");
+a[c]=c in a?a[c].add(d):d});b.each(a,function(){this.matchHeight(!0)})};b.fn.matchHeight._groups=[];var g=-1;b.fn.matchHeight._update=function(a){if(a&&"resize"===a.type){a=b(window).width();if(a===g)return;g=a}b.each(b.fn.matchHeight._groups,function(){b.fn.matchHeight._apply(this.elements,this.byRow)})};b(b.fn.matchHeight._applyDataApi);b(window).bind("load resize orientationchange",b.fn.matchHeight._update);var k=function(a){var d=null,c=[];b(a).each(function(){var a=b(this),g=a.offset().top-f(a.css("margin-top")),
+h=0<c.length?c[c.length-1]:null;null===h?c.push(a):1>=Math.floor(Math.abs(d-g))?c[c.length-1]=h.add(a):c.push(a);d=g});return c},f=function(a){return parseFloat(a)||0}})(jQuery);

--- a/js/teasers.js
+++ b/js/teasers.js
@@ -1,0 +1,19 @@
+jQuery(function ($) {
+
+    $('.view-content > .campl-row').each(function () {
+        var $teasers = $('.campl-teaser-border', this);
+
+        if (Modernizr.mq('only screen and (min-width: 768px)')) {
+            $teasers.matchHeight(false);
+        }
+
+        $(window).resize(function () {
+            if (Modernizr.mq('only screen and (max-width: 767px)')) {
+                $teasers.height('auto');
+            } else {
+                $teasers.matchHeight(false);
+            }
+        });
+    });
+
+});

--- a/templates/node----teaser.tpl.php
+++ b/templates/node----teaser.tpl.php
@@ -23,8 +23,8 @@ $has_image = isset($content['field_image']);
 
 ?>
 
-<div class="campl-content-container <?php print $classes; ?>" <?php print $attributes; ?>>
-  <div class="campl-horizontal-teaser campl-teaser clearfix">
+<div class="campl-content-container campl-vertical-padding <?php print $classes; ?>" <?php print $attributes; ?>>
+  <div class="campl-horizontal-teaser campl-teaser campl-teaser-border campl-content-container campl-side-padding clearfix">
     <?php if ($has_image): ?>
       <div class="campl-column6">
         <div class="campl-content-container campl-horizontal-teaser-img">
@@ -45,4 +45,8 @@ $has_image = isset($content['field_image']);
       </div>
     </div>
   </div>
+</div>
+
+<div class="campl-content-container campl-side-padding">
+  <hr class="campl-teaser-divider">
 </div>

--- a/templates/node----vertical-teaser.tpl.php
+++ b/templates/node----vertical-teaser.tpl.php
@@ -21,8 +21,8 @@ endif;
 
 ?>
 
-<div class="campl-content-container <?php print $classes; ?>" <?php print $attributes; ?>>
-  <div class="campl-vertical-teaser campl-teaser">
+<div class="campl-content-container campl-vertical-padding <?php print $classes; ?>" <?php print $attributes; ?>>
+  <div class="campl-vertical-teaser campl-teaser campl-teaser-border campl-content-container campl-side-padding">
     <?php if (array_key_exists('field_image', $content)): ?>
       <div class="campl-content-container campl-vertical-teaser-img">
         <?php print render($content['field_image']); ?>
@@ -38,5 +38,10 @@ endif;
       <?php print render($content); ?>
       <a href="<?php print $url; ?>" class="campl-primary-cta"><?php print $read_more; ?></a>
     </div>
+
   </div>
+</div>
+
+<div class="campl-content-container campl-side-padding">
+  <hr class="campl-teaser-divider">
 </div>

--- a/templates/views-view-unformatted.tpl.php
+++ b/templates/views-view-unformatted.tpl.php
@@ -1,0 +1,94 @@
+<?php if (!empty($title)): ?>
+  <h3><?php print $title; ?></h3>
+<?php endif; ?>
+
+<?php
+$teasers = FALSE;
+$columnsInRow = 0;
+$i = 0;
+?>
+
+<?php foreach ($rows as $id => $row): ?>
+  <?php
+  $i++;
+  $columns = NULL;
+
+  $attributes = array();
+
+  if ($classes_array[$id]) {
+    preg_match('/campl-column([0-9]+)/', $classes_array[$id], $matches);
+    if (isset($matches[1])) {
+      $columns = (int) $matches[1];
+    }
+    $attributes['class'][] = $classes_array[$id];
+  }
+
+  $teasers = (FALSE !== strpos($row, 'campl-horizontal-teaser')) + (FALSE !== strpos($row, 'campl-vertical-teaser'));
+
+  if ((FALSE !== strpos($row, 'campl-focus-teaser')) + (FALSE !== strpos($row, 'campl-promo-teaser'))) {
+    $teasers = FALSE; // avoid false positives
+  }
+
+  if ($columns) {
+    if ($teasers) {
+      $attributes['class'][] = 'campl-hide-teaser-divider campl-teasers-borders';
+    }
+
+    if (0 === $columnsInRow) {
+      // start of a new row
+      $attributes['class'][] .= 'campl-column-first';
+      print '<div class="campl-row">';
+    }
+    elseif (($columnsInRow + $columns) > 12) {
+      // we're going to overflow a row (ie it doesn't add up to 12), so start again
+      $attributes['class'][] .= 'campl-column-last';
+
+      print '</div>';
+
+      if ($teasers) {
+        print '<div class="campl-column12"><div class="campl-content-container campl-side-padding"><hr class="campl-teaser-divider"></div></div>';
+      }
+
+      print '<div class="campl-row">';
+      $columnsInRow = 0;
+    }
+    elseif (($columnsInRow + $columns) == 12) {
+      $attributes['class'][] .= 'campl-column-last';
+      $attributes['class'][] .= 'campl-column-end';
+    }
+
+    if ($i === count($rows) && ($columnsInRow + $columns) < 12) {
+      $attributes['class'][] .= 'campl-column-last';
+    }
+  }
+  ?>
+  <div<?php print drupal_attributes($attributes); ?>>
+    <?php print $row; ?>
+  </div>
+  <?php
+
+  if ($columns) {
+    if (($columnsInRow + $columns) == 12) {
+      print '</div>';
+      if ($teasers) {
+        print '<div class="campl-column12"><div class="campl-content-container campl-side-padding"><hr class="campl-teaser-divider"></div></div>';
+      }
+      $columnsInRow = 0;
+    }
+    else {
+      $columnsInRow += $columns;
+    }
+  }
+
+  ?>
+<?php endforeach; ?>
+
+<?php
+if ($columnsInRow > 0) {
+  // the last row is open, so close it
+  print '</div>';
+  if ($teasers) {
+    print '<div class="campl-column12"><div class="campl-content-container campl-side-padding"><hr class="campl-teaser-divider"></div></div>';
+  }
+}
+?>


### PR DESCRIPTION
This adds borders around horizontal and vertical teasers. Fixes #5.

Because individual parts of the templating don't know what follows it ends up adding in a border beneath which shouldn't be there. JavaScript has been added for cases to remove the redundant border beneath an individual teaser when the row also has one. (As a side effect, it resolves the mobile view problem mentioned on https://github.com/cambridgeuniversity/Project-Light/issues/53 and it can be unhidden at this size - except for the last one on the row.)

This doesn't remove the bottom row border where the teasers are the last thing, eg

![image](https://cloud.githubusercontent.com/assets/1784740/2799226/6d35fc0c-cc5c-11e3-9e58-50a06cbbe36a.png)

It _might_ be possible to use JavaScript to work it out and hide it accordingly, but that won't be trivial.
