### PR TITLE
Remove unnecessary padding when a sidebar teaser doesn't have an image

### DIFF
--- a/css/teasers.css
+++ b/css/teasers.css
@@ -1,3 +1,7 @@
+.campl-promo-teaser .campl-vertical-teaser-txt.campl-no-top-padding {
+    padding-top: 0;
+}
+
 .campl-teasers-borders .campl-teaser-border {
     border-left: 1px solid #e4e4e4;
     margin-left: -1px;

--- a/templates/node----sidebar-teaser.tpl.php
+++ b/templates/node----sidebar-teaser.tpl.php
@@ -19,6 +19,8 @@ else:
   $read_more = t('Read more');
 endif;
 
+$has_image = isset($content['field_image']);
+
 ?>
 
 <div class="campl-content-container <?php print $classes; ?>" <?php print $attributes; ?>>
@@ -28,12 +30,12 @@ endif;
       <p class='campl-teaser-title'><a href="<?php print $url; ?>"><?php print $title; ?></a></p>
       <?php print render($title_suffix); ?>
     </div>
-    <?php if (array_key_exists('field_image', $content)): ?>
+    <?php if ($has_image): ?>
       <div class="campl-content-container campl-vertical-teaser-img">
         <?php print render($content['field_image']); ?>
       </div>
     <?php endif; ?>
-    <div class="campl-content-container campl-vertical-teaser-txt clearfix">
+    <div class="campl-content-container<?php if (!$has_image): print ' campl-no-top-padding'; endif; ?> campl-vertical-teaser-txt clearfix">
       <?php if ($display_submitted): ?>
         <p class="campl-datestamp"><?php print $date; ?></p>
       <?php endif; ?>


### PR DESCRIPTION
Both the heading and body in a sidebar teaser have content containers, but when there's no image it leaves a big gap between the two. This removes the top padding on the content, so:

![image](https://cloud.githubusercontent.com/assets/1784740/2800567/91bbf3c4-cc75-11e3-9aaf-34a5495af5c5.png)

becomes:

![image](https://cloud.githubusercontent.com/assets/1784740/2800574/a07de9bc-cc75-11e3-95b5-6111a018e13b.png)
