### PR TITLE
Add clearfix to rows

### DIFF
--- a/templates/views-view-unformatted.tpl.php
+++ b/templates/views-view-unformatted.tpl.php
@@ -37,7 +37,7 @@ $i = 0;
     if (0 === $columnsInRow) {
       // start of a new row
       $attributes['class'][] .= 'campl-column-first';
-      print '<div class="campl-row">';
+      print '<div class="campl-row clearfix">';
     }
     elseif (($columnsInRow + $columns) > 12) {
       // we're going to overflow a row (ie it doesn't add up to 12), so start again
@@ -49,7 +49,7 @@ $i = 0;
         print '<div class="campl-column12"><div class="campl-content-container campl-side-padding"><hr class="campl-teaser-divider"></div></div>';
       }
 
-      print '<div class="campl-row">';
+      print '<div class="campl-row clearfix">';
       $columnsInRow = 0;
     }
     elseif (($columnsInRow + $columns) == 12) {


### PR DESCRIPTION
Not completing a row can cause the next item (eg pagination) to float up:

![image](https://cloud.githubusercontent.com/assets/1784740/7199317/b63e8f6a-e4eb-11e4-8a09-0b63bfc508a9.png)

This adds `clearfix` to `campl-row`s. (It would be simpler to add it to the same level as `view-content`, but that involves overriding another template.)