### PR TITLE
Use Behaviors

### DIFF
--- a/js/teasers.js
+++ b/js/teasers.js
@@ -1,19 +1,23 @@
-jQuery(function ($) {
+(function ($) {
 
-    $('.view-content > .campl-row').each(function () {
-        var $teasers = $('.campl-teaser-border', this);
+    Drupal.behaviors.cambridgeTeasers = {
+        attach: function (context, settings) {
+            $('.view-content > .campl-row', context).each(function () {
+                var $teasers = $('.campl-teaser-border', this);
 
-        if (Modernizr.mq('only screen and (min-width: 768px)')) {
-            $teasers.matchHeight(false);
+                if (Modernizr.mq('only screen and (min-width: 768px)')) {
+                    $teasers.matchHeight(false);
+                }
+
+                $(window).resize(function () {
+                    if (Modernizr.mq('only screen and (max-width: 767px)')) {
+                        $teasers.height('auto');
+                    } else {
+                        $teasers.matchHeight(false);
+                    }
+                });
+            });
         }
+    };
 
-        $(window).resize(function () {
-            if (Modernizr.mq('only screen and (max-width: 767px)')) {
-                $teasers.height('auto');
-            } else {
-                $teasers.matchHeight(false);
-            }
-        });
-    });
-
-});
+})(jQuery);


### PR DESCRIPTION
The matching-heights JavaScript isn't currently applied to content loaded through Ajax. Using Drupal Behaviors fixes this.